### PR TITLE
Feature/7 table of contents

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,11 @@ baseURL = 'https://sfmunoz.com/'
 languageCode = 'en-us'
 title = 'CMS'
 
+[markup]
+  [markup.tableOfContents]
+    startLevel = 2
+    endLevel = 6
+
 [menus]
   [[menus.main]]
     name = 'Home'

--- a/themes/headless/layouts/page.html
+++ b/themes/headless/layouts/page.html
@@ -5,6 +5,8 @@
   {{ $dateHuman := .Date | time.Format ":date_long" }}
   <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
 
+  {{ .TableOfContents }}
+
   {{ .Content }}
   {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
 {{ end }}

--- a/themes/standalone/layouts/page.html
+++ b/themes/standalone/layouts/page.html
@@ -5,6 +5,8 @@
   {{ $dateHuman := .Date | time.Format ":date_long" }}
   <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
 
+  {{ .TableOfContents }}
+
   {{ .Content }}
   {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
 {{ end }}


### PR DESCRIPTION
It's done:

- `{{ .TableOfContents }}` added to `layouts/page.html` in **standalone** and **headless** themes.
- **hugo.toml** configured
  - markup.tableOfContents.startLevel = 2
  - markup.tableOfContents.endLevel = 6