### PR TITLE
Feature/18 mermaid

### DIFF
--- a/layouts/_markup/render-codeblock-mermaid.html
+++ b/layouts/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+<pre class="mermaid">
+  {{ .Inner | htmlEscape | safeHTML }}
+</pre>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/themes/headless/layouts/baseof.html
+++ b/themes/headless/layouts/baseof.html
@@ -1,1 +1,7 @@
 {{ block "main" . }}{{ end }}
+{{ if and hugo.IsServer (.Store.Get "hasMermaid") }}
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+{{ end }}

--- a/themes/standalone/layouts/baseof.html
+++ b/themes/standalone/layouts/baseof.html
@@ -13,5 +13,11 @@
   <footer>
     {{ partial "footer.html" . }}
   </footer>
+{{ if .Store.Get "hasMermaid" }}
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+{{ end }}
 </body>
 </html>


### PR DESCRIPTION
It's done:

- **render-codeblock-mermaid.html** has been created
- **standalone** always makes use of https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs
- **headless** makes use of https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs when **hugo.IsServer=true**